### PR TITLE
add a base gui setup/layout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
+plugins {
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
+}
+
 apply plugin: 'java'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'ElementalArmor'
 version = '1.0-SNAPSHOT'
@@ -28,8 +33,15 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 
+shadowJar {
+    classifier ''
+    relocate 'me.mattstudios.mfgui', 'ca.minecore.elementalarmor.libs.mfgui'
+}
+
 processResources {
     from(sourceSets.main.resources.srcDirs) {
         filter ReplaceTokens, tokens: [version: version]
     }
 }
+
+tasks.build.dependsOn tasks.shadowJar

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 
 dependencies {
     implementation 'org.jetbrains:annotations:19.0.0'
+    implementation "me.mattstudios.utils:matt-framework-gui:2.0.2"
+
     compileOnly 'org.spigotmc:spigot-api:1.16.3-R0.1-SNAPSHOT'
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -47,7 +47,8 @@ public final class Main extends JavaPlugin {
         saveConfig(false);
         loadSavedFrozenLava();
 
-        // register commands & liseners
+        // register commands & liseners & managers
+        registerManager();
         registerCommands();
         registerListeners();
 
@@ -133,5 +134,9 @@ public final class Main extends JavaPlugin {
         // water
         pm.registerEvents(new FastSwim(), this);
 
+    }
+
+    private void registerManager() {
+        inventoryManager = new InventoryManager(this);
     }
 }

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -4,6 +4,7 @@ import ca.minecore.elementalarmor.commands.Bind;
 import ca.minecore.elementalarmor.commands.GiveArmor;
 import ca.minecore.elementalarmor.commands.GiveCharm;
 import ca.minecore.elementalarmor.commands.SetCharm;
+import ca.minecore.elementalarmor.gui.InventoryManager;
 import ca.minecore.elementalarmor.listeners.air.DoubleJump;
 import ca.minecore.elementalarmor.listeners.air.ElytraBoost;
 import ca.minecore.elementalarmor.listeners.air.PushNearby;
@@ -33,6 +34,12 @@ public final class Main extends JavaPlugin {
     public static Main plugin;
     public static YamlConfiguration data;
 
+    private InventoryManager inventoryManager;
+
+    public InventoryManager getInventoryManager() {
+        return inventoryManager;
+    }
+
     static {
         ConfigurationSerialization.registerClass(FrozenLava.class, "FrozenLava");
     }
@@ -42,6 +49,8 @@ public final class Main extends JavaPlugin {
         plugin = this;
         saveConfig(false);
         loadSavedFrozenLava();
+
+        inventoryManager = new InventoryManager(this);
 
         Objects.requireNonNull(getCommand("givearmor")).setExecutor(new GiveArmor());
         Objects.requireNonNull(getCommand("givearmor")).setTabCompleter(new GiveArmor());

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -109,6 +109,7 @@ public final class Main extends JavaPlugin {
         new SetCharm(this);
         new GiveCharm(this);
         new Bind(this);
+        new GuiDebug(this);
     }
 
     // regiter the listeners of the plugin

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -31,14 +31,14 @@ public final class Main extends JavaPlugin {
     public static Main plugin;
     public static YamlConfiguration data;
 
+    static {
+        ConfigurationSerialization.registerClass(FrozenLava.class, "FrozenLava");
+    }
+
     private InventoryManager inventoryManager;
 
     public InventoryManager getInventoryManager() {
         return inventoryManager;
-    }
-
-    static {
-        ConfigurationSerialization.registerClass(FrozenLava.class, "FrozenLava");
     }
 
     @Override

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -1,9 +1,6 @@
 package ca.minecore.elementalarmor;
 
-import ca.minecore.elementalarmor.commands.Bind;
-import ca.minecore.elementalarmor.commands.GiveArmor;
-import ca.minecore.elementalarmor.commands.GiveCharm;
-import ca.minecore.elementalarmor.commands.SetCharm;
+import ca.minecore.elementalarmor.commands.*;
 import ca.minecore.elementalarmor.gui.InventoryManager;
 import ca.minecore.elementalarmor.listeners.air.DoubleJump;
 import ca.minecore.elementalarmor.listeners.air.ElytraBoost;
@@ -60,6 +57,7 @@ public final class Main extends JavaPlugin {
         Objects.requireNonNull(getCommand("givecharm")).setTabCompleter(new GiveCharm());
         Objects.requireNonNull(getCommand("bind")).setExecutor(new Bind());
         Objects.requireNonNull(getCommand("bind")).setTabCompleter(new Bind());
+        new GuiDebug(this);
 
         getServer().getPluginManager().registerEvents(new AddCharm(), this);
         getServer().getPluginManager().registerEvents(new SoulBinding(), this);

--- a/src/main/java/ca/minecore/elementalarmor/Main.java
+++ b/src/main/java/ca/minecore/elementalarmor/Main.java
@@ -18,13 +18,13 @@ import ca.minecore.elementalarmor.util.elements.fire.FrozenLava;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public final class Main extends JavaPlugin {
 
@@ -47,35 +47,9 @@ public final class Main extends JavaPlugin {
         saveConfig(false);
         loadSavedFrozenLava();
 
-        inventoryManager = new InventoryManager(this);
-
-        Objects.requireNonNull(getCommand("givearmor")).setExecutor(new GiveArmor());
-        Objects.requireNonNull(getCommand("givearmor")).setTabCompleter(new GiveArmor());
-        Objects.requireNonNull(getCommand("setcharm")).setExecutor(new SetCharm());
-        Objects.requireNonNull(getCommand("setcharm")).setTabCompleter(new SetCharm());
-        Objects.requireNonNull(getCommand("givecharm")).setExecutor(new GiveCharm());
-        Objects.requireNonNull(getCommand("givecharm")).setTabCompleter(new GiveCharm());
-        Objects.requireNonNull(getCommand("bind")).setExecutor(new Bind());
-        Objects.requireNonNull(getCommand("bind")).setTabCompleter(new Bind());
-        new GuiDebug(this);
-
-        getServer().getPluginManager().registerEvents(new AddCharm(), this);
-        getServer().getPluginManager().registerEvents(new SoulBinding(), this);
-
-        // air
-        getServer().getPluginManager().registerEvents(new SlowFall(), this);
-        getServer().getPluginManager().registerEvents(new DoubleJump(), this);
-        getServer().getPluginManager().registerEvents(new ElytraBoost(), this);
-        getServer().getPluginManager().registerEvents(new PushNearby(), this);
-        // fire
-        getServer().getPluginManager().registerEvents(new Fireproof(), this);
-        getServer().getPluginManager().registerEvents(new LavaWalking(), this);
-        getServer().getPluginManager().registerEvents(new FireThorns(), this);
-        getServer().getPluginManager().registerEvents(new Explosion(this), this);
-        // earth
-        getServer().getPluginManager().registerEvents(new Telekinesis(), this);
-        // water
-        getServer().getPluginManager().registerEvents(new FastSwim(), this);
+        // register commands & liseners
+        registerCommands();
+        registerListeners();
 
         startRepeatingTasks();
     }
@@ -126,5 +100,37 @@ public final class Main extends JavaPlugin {
 
     private void startRepeatingTasks() {
         LavaWalking.startRepeatingTask();
+    }
+
+    // register all the plugins commands
+    // each constructor of the following classes registers
+    private void registerCommands() {
+        new GiveArmor(this);
+        new SetCharm(this);
+        new GiveCharm(this);
+        new Bind(this);
+    }
+
+    // regiter the listeners of the plugin
+    private void registerListeners() {
+        PluginManager pm = getServer().getPluginManager();
+        pm.registerEvents(new AddCharm(), this);
+        pm.registerEvents(new SoulBinding(), this);
+
+        // air
+        pm.registerEvents(new SlowFall(), this);
+        pm.registerEvents(new DoubleJump(), this);
+        pm.registerEvents(new ElytraBoost(), this);
+        pm.registerEvents(new PushNearby(), this);
+        // fire
+        pm.registerEvents(new Fireproof(), this);
+        pm.registerEvents(new LavaWalking(), this);
+        pm.registerEvents(new FireThorns(), this);
+        pm.registerEvents(new Explosion(this), this);
+        // earth
+        pm.registerEvents(new Telekinesis(), this);
+        // water
+        pm.registerEvents(new FastSwim(), this);
+
     }
 }

--- a/src/main/java/ca/minecore/elementalarmor/commands/Bind.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/Bind.java
@@ -1,13 +1,11 @@
 package ca.minecore.elementalarmor.commands;
 
+import ca.minecore.elementalarmor.Main;
 import ca.minecore.elementalarmor.util.ArmorManager;
 import ca.minecore.elementalarmor.util.CustomArmor;
 import ca.minecore.elementalarmor.util.emums.ArmorType;
 import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
+import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +15,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Bind implements CommandExecutor, TabCompleter {
+
+    private Main plugin;
+    public Bind(Main plugin) {
+        this.plugin = plugin;
+        PluginCommand cmd = plugin.getCommand("bind");
+        if (cmd != null) {
+            cmd.setTabCompleter(this);
+            cmd.setExecutor(this);
+        } else plugin.getLogger().severe("Bind Command was null!");
+    }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 1) {

--- a/src/main/java/ca/minecore/elementalarmor/commands/GiveArmor.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/GiveArmor.java
@@ -1,5 +1,6 @@
 package ca.minecore.elementalarmor.commands;
 
+import ca.minecore.elementalarmor.Main;
 import ca.minecore.elementalarmor.util.ArmorManager;
 import ca.minecore.elementalarmor.util.CustomArmor;
 import ca.minecore.elementalarmor.util.emums.ArmorPiece;
@@ -8,10 +9,7 @@ import ca.minecore.elementalarmor.util.emums.Charm;
 import ca.minecore.elementalarmor.util.exceptions.InvalidCharmException;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
+import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -20,6 +18,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GiveArmor implements CommandExecutor, TabCompleter {
+
+    private Main plugin;
+
+    public GiveArmor(Main plugin) {
+        this.plugin = plugin;
+        PluginCommand cmd = plugin.getCommand("givearmor");
+        if (cmd != null) {
+            cmd.setTabCompleter(this);
+            cmd.setExecutor(this);
+        } else plugin.getLogger().severe("Give Armor Command was null!");
+    }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         switch (args.length) {

--- a/src/main/java/ca/minecore/elementalarmor/commands/GiveCharm.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/GiveCharm.java
@@ -1,11 +1,9 @@
 package ca.minecore.elementalarmor.commands;
 
+import ca.minecore.elementalarmor.Main;
 import ca.minecore.elementalarmor.util.emums.Charm;
 import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
+import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,6 +12,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GiveCharm implements CommandExecutor, TabCompleter {
+
+    private Main plugin;
+
+    public GiveCharm(Main plugin) {
+        this.plugin = plugin;
+        PluginCommand cmd = plugin.getCommand("givecharm");
+        if (cmd != null) {
+            cmd.setTabCompleter(this);
+            cmd.setExecutor(this);
+        } else plugin.getLogger().severe("Give Charm Command was null!");
+    }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 2) {

--- a/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
@@ -1,0 +1,40 @@
+package ca.minecore.elementalarmor.commands;
+
+import ca.minecore.elementalarmor.Main;
+import org.bukkit.command.*;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class GuiDebug implements CommandExecutor, @Nullable TabCompleter {
+
+    private Main plugin;
+
+    public GuiDebug(Main plugin) {
+        this.plugin = plugin;
+        PluginCommand cmd = plugin.getCommand("guidebug");
+        if (cmd != null) {
+            cmd.setExecutor(this);
+            cmd.setTabCompleter(this);
+        } else plugin.getLogger().severe("GUIDebug Command Was Null!");
+    }
+
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission("enigma.debug.gui") || !(sender instanceof Player)) return false;
+
+        Player player = (Player) sender;
+        plugin.getInventoryManager().getHomePage().getGui(player).open(player);
+
+        return false;
+    }
+
+    // TODO
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        return null;
+    }
+}

--- a/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
@@ -24,7 +24,7 @@ public class GuiDebug implements CommandExecutor, @Nullable TabCompleter {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (!sender.hasPermission("enigma.debug.gui") || !(sender instanceof Player)) return false;
+        if (!sender.hasPermission("elementalarmor.admin.debuggui") || !(sender instanceof Player)) return false;
 
         Player player = (Player) sender;
         plugin.getInventoryManager().getHomePage().getGui(player).open(player);

--- a/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/GuiDebug.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class GuiDebug implements CommandExecutor, @Nullable TabCompleter {
 
-    private Main plugin;
+    private final Main plugin;
 
     public GuiDebug(Main plugin) {
         this.plugin = plugin;

--- a/src/main/java/ca/minecore/elementalarmor/commands/SetCharm.java
+++ b/src/main/java/ca/minecore/elementalarmor/commands/SetCharm.java
@@ -1,5 +1,6 @@
 package ca.minecore.elementalarmor.commands;
 
+import ca.minecore.elementalarmor.Main;
 import ca.minecore.elementalarmor.util.ArmorManager;
 import ca.minecore.elementalarmor.util.CustomArmor;
 import ca.minecore.elementalarmor.util.emums.ArmorType;
@@ -7,10 +8,7 @@ import ca.minecore.elementalarmor.util.emums.Charm;
 import ca.minecore.elementalarmor.util.exceptions.InvalidCharmException;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabCompleter;
+import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -20,6 +18,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SetCharm implements CommandExecutor, TabCompleter {
+
+    private Main plugin;
+
+    public SetCharm(Main plugin) {
+        this.plugin = plugin;
+        // command registering
+        PluginCommand cmd = plugin.getCommand("givecharm");
+        if (cmd != null) {
+            cmd.setTabCompleter(this);
+            cmd.setExecutor(this);
+        } else plugin.getLogger().severe("Set Charm Command was null!");
+    }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 2) {

--- a/src/main/java/ca/minecore/elementalarmor/gui/AbstractEnigmaGUI.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/AbstractEnigmaGUI.java
@@ -1,0 +1,15 @@
+package ca.minecore.elementalarmor.gui;
+
+import me.mattstudios.mfgui.gui.guis.Gui;
+import org.bukkit.entity.Player;
+
+abstract public class AbstractEnigmaGUI {
+    /**
+     * A method to get the GUI of a given GUI Page
+     *
+     * @param player a player for the placeholders and such of the gui
+     * @return the gui
+     */
+    public abstract Gui getGui(Player player);
+
+}

--- a/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player;
 public class InventoryManager {
 
     private Main plugin;
-    private HomePage homePage;
+    private final HomePage homePage;
 
     public InventoryManager(Main plugin) {
         this.plugin = plugin;

--- a/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
@@ -1,0 +1,36 @@
+package ca.minecore.elementalarmor.gui;
+
+import ca.minecore.elementalarmor.Main;
+import ca.minecore.elementalarmor.gui.pages.HomePage;
+import org.bukkit.entity.Player;
+
+/**
+ * Inventory Manager class
+ * will have a reference to all the different inventories, and will have an instance in the Main Class
+ * <p>
+ */
+public class InventoryManager {
+
+    private Main plugin;
+    private HomePage homePage;
+
+    public InventoryManager(Main plugin) {
+        this.plugin = plugin;
+        homePage = new HomePage();
+    }
+
+    /**
+     * Method to open any of the GUI's
+     * @param gui - the AbstractEnigmaGUI that we want to open
+     * @param player - the player who we are opening it for
+     */
+    public void openGui(AbstractEnigmaGUI gui, Player player) {
+        gui.getGui(player).open(player);
+    }
+
+    // return the homepage class where we can call
+    public HomePage getHomePage() {
+        return homePage;
+    }
+
+}

--- a/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/InventoryManager.java
@@ -11,8 +11,8 @@ import org.bukkit.entity.Player;
  */
 public class InventoryManager {
 
-    private Main plugin;
     private final HomePage homePage;
+    private Main plugin;
 
     public InventoryManager(Main plugin) {
         this.plugin = plugin;
@@ -21,7 +21,8 @@ public class InventoryManager {
 
     /**
      * Method to open any of the GUI's
-     * @param gui - the AbstractEnigmaGUI that we want to open
+     *
+     * @param gui    - the AbstractEnigmaGUI that we want to open
      * @param player - the player who we are opening it for
      */
     public void openGui(AbstractEnigmaGUI gui, Player player) {

--- a/src/main/java/ca/minecore/elementalarmor/gui/pages/HomePage.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/pages/HomePage.java
@@ -1,0 +1,17 @@
+package ca.minecore.elementalarmor.gui.pages;
+
+import ca.minecore.elementalarmor.gui.AbstractEnigmaGUI;
+import ca.minecore.elementalarmor.util.ChatUtil;
+import me.mattstudios.mfgui.gui.guis.Gui;
+import org.bukkit.entity.Player;
+
+public class HomePage extends AbstractEnigmaGUI {
+
+    @Override
+    public Gui getGui(Player player) {
+        Gui gui = new Gui(5, ChatUtil.colorize("&6Minecore &7- &bEnigma"));
+
+        return gui;
+    }
+
+}

--- a/src/main/java/ca/minecore/elementalarmor/gui/pages/HomePage.java
+++ b/src/main/java/ca/minecore/elementalarmor/gui/pages/HomePage.java
@@ -9,7 +9,7 @@ public class HomePage extends AbstractEnigmaGUI {
 
     @Override
     public Gui getGui(Player player) {
-        Gui gui = new Gui(5, ChatUtil.colorize("&6Minecore &7- &bEnigma"));
+        Gui gui = new Gui(5, ChatUtil.colorize("&eMinecore &7- &bEnigma"));
 
         return gui;
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,3 +23,7 @@ commands:
     description: Bind an armor piece to a player
     usage: /bind <player>
     permission: elementalarmor.admin.bind
+  guidebug:
+    description: Debug the GUI
+    usage: /guidebug
+    permission: elementalarmor.admin.debuggui


### PR DESCRIPTION
@bonn2 only merge if you want to do the idea from #23 

all this did was create a basic layout for different GUIs / pages (and an abstract class to make sure we always have the same open method).

I used [mf-gui](https://mf.mattstudios.me/mf-gui/gui) which is a great GUI library which makes it really easy to do this type of thing. you can handle the click event for each item individually, easily create paginated things, etc. i use it anytime I use a gui in a plugin